### PR TITLE
Feature/admin reservations

### DIFF
--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -1,8 +1,8 @@
-import { NestFactory } from '@nestjs/core';
-import { AppModule } from './app.module';
-import { FastifyAdapter } from '@nestjs/platform-fastify/adapters';
-import { NestFastifyApplication } from '@nestjs/platform-fastify';
 import { ValidationPipe } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import { NestFastifyApplication } from '@nestjs/platform-fastify';
+import { FastifyAdapter } from '@nestjs/platform-fastify/adapters';
+import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestFastifyApplication>(
@@ -11,6 +11,12 @@ async function bootstrap() {
       logger: true,
     }),
   );
+
+  app.enableCors({
+    origin: '*',
+    methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
+    credentials: true,
+  });
 
   app.useGlobalPipes(new ValidationPipe());
   await app.listen(process.env.PORT ?? 3000, '0.0.0.0');

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -49,3 +49,5 @@ app.*.map.json
 /windows/
 /linux/
 /web/
+
+env.dart

--- a/app/lib/config/env.dart.example
+++ b/app/lib/config/env.dart.example
@@ -1,0 +1,18 @@
+class Env {
+  static const String apiUrl = 'http://localhost:3000';
+  
+  // Configuration pour Android
+  static const String androidApiUrl = 'http://10.0.2.2:3000';
+  
+  // Configuration pour iOS
+  static const String iosApiUrl = 'http://localhost:3000';
+  
+  // Token d'authentification (à déplacer dans un système de gestion de tokens plus sécurisé)
+  static const String authToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImFkbWluQGFkbWluLmNvbSIsImlkIjoiNjA3YWZmNjItYzYyOS00MDM3LTkwMzgtNzA1ZDI0MDljMzY4Iiwicm9sZXMiOlsiYWRtaW4iXSwiaWF0IjoxNzQ4MjcxODI5LCJleHAiOjE3NDgyNzU0Mjl9.VCc_bcMmMjdkPoZEnv9lHfSS-_HJqFJlbP5wGWoKqlc';
+  
+  // Headers par défaut pour les requêtes API
+  static Map<String, String> get defaultHeaders => {
+    'Content-Type': 'application/json',
+    'Authorization': 'Bearer $authToken',
+  };
+} 

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter_restaurant_app/pages/reservation_page.dart';
 import 'package:flutter_restaurant_app/pages/restaurant_detail_page.dart';
 import 'package:flutter_restaurant_app/pages/restaurant_menu_page.dart';
 import 'package:flutter_restaurant_app/pages/utilisateur_page.dart';
+import 'package:flutter_restaurant_app/pages/admin_reservations_page.dart';
 import 'package:flutter_restaurant_app/models/dish_category.dart';
 import 'package:flutter_restaurant_app/models/restaurant.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -44,7 +45,8 @@ class _MainScreenState extends State<MainScreen> {
     const RestaurantDetailPage(),
     const RestaurantMenuPage(title: ''),
     const ReservationPage(),
-    const UtilisateurPage()
+    const UtilisateurPage(),
+    const AdminReservationsPage(),
   ];
 
   // Récupère l'écran à partir d'un index
@@ -88,9 +90,13 @@ class _MainScreenState extends State<MainScreen> {
           BottomNavigationBarItem(
               icon: Icon(Icons.event_note),
               label: 'Profile'
-          )
+          ),
+          BottomNavigationBarItem(
+              icon: Icon(Icons.admin_panel_settings),
+              label: 'Admin'
+          ),
         ],
-      ), // Current index dépend de la page affiché
+      ),
     );
   }
 }

--- a/app/lib/models/reservation.dart
+++ b/app/lib/models/reservation.dart
@@ -2,6 +2,7 @@ import 'package:flutter_restaurant_app/models/restaurant_table.dart';
 import 'package:flutter_restaurant_app/models/time_slots.dart';
 
 class Reservation {
+  final String id;
   final int covers;
   final String date;
   final TimeSlots timeSlot;
@@ -9,6 +10,7 @@ class Reservation {
   final String status;
 
   Reservation({
+    required this.id,
     required this.covers,
     required this.date,
     required this.timeSlot,
@@ -19,6 +21,7 @@ class Reservation {
   factory Reservation.fromJson(Map<String, dynamic> json) {
     print(json);
     return Reservation(
+      id: json['id'],
       covers: json['covers'],
       date: json['reservationDate'],
       timeSlot: new TimeSlots(startTime: json['timeSlot']['startTime'], endTime: json['timeSlot']['endTime']),

--- a/app/lib/pages/admin_reservations_page.dart
+++ b/app/lib/pages/admin_reservations_page.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_restaurant_app/models/reservation.dart';
+import 'package:flutter_restaurant_app/service/reservation_service.dart';
+//import 'package:intl/intl.dart';
+
+class AdminReservationsPage extends StatefulWidget {
+  const AdminReservationsPage({super.key});
+
+  @override
+  State<AdminReservationsPage> createState() => _AdminReservationsPageState();
+}
+
+class _AdminReservationsPageState extends State<AdminReservationsPage> {
+  List<Reservation> _reservations = [];
+  bool _isLoading = true;
+  String _error = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _loadReservations();
+  }
+
+  Future<void> _loadReservations() async {
+    try {
+      setState(() {
+        _isLoading = true;
+        _error = '';
+      });
+
+      final reservations = await fetchReservations();
+      setState(() {
+        _reservations = reservations;
+        _isLoading = false;
+      });
+    } catch (e) {
+      setState(() {
+        _error = 'Erreur lors du chargement des réservations';
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _updateReservationStatus(Reservation reservation, String newStatus) async {
+    try {
+      await updateReservationStatus(reservation.id, newStatus);
+      await _loadReservations(); // Recharger les réservations après la mise à jour
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Statut mis à jour avec succès')),
+      );
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Erreur lors de la mise à jour du statut')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_error.isNotEmpty) {
+      return Center(child: Text(_error));
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Gestion des Réservations'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: _loadReservations,
+          ),
+        ],
+      ),
+      body: ListView.builder(
+        itemCount: _reservations.length,
+        itemBuilder: (context, index) {
+          final reservation = _reservations[index];
+          return Card(
+            margin: const EdgeInsets.all(8.0),
+            child: ListTile(
+              title: Text('Table ${reservation.restaurantTable.name} - ${reservation.covers} personnes'),
+              subtitle: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Date: ${reservation.date}'),
+                  Text('Horaire: ${reservation.timeSlot.startTime} - ${reservation.timeSlot.endTime}'),
+                  Text('Statut: ${reservation.status}'),
+                ],
+              ),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (reservation.status == 'PENDING')
+                    IconButton(
+                      icon: const Icon(Icons.check, color: Colors.green),
+                      onPressed: () => _updateReservationStatus(reservation, 'ACCEPTED'),
+                    ),
+                  if (reservation.status == 'PENDING')
+                    IconButton(
+                      icon: const Icon(Icons.close, color: Colors.red),
+                      onPressed: () => _updateReservationStatus(reservation, 'REJECTED'),
+                    ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+} 

--- a/app/lib/service/reservation_service.dart
+++ b/app/lib/service/reservation_service.dart
@@ -1,23 +1,18 @@
 import 'dart:convert';
-
 import 'package:http/http.dart' as http;
-
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'dart:io' show Platform;
 import '../models/reservation.dart';
+import '../config/env.dart';
 
 Future<List<Reservation>> fetchReservations() async {
-  // TODO En fonction de l'utilisateur changé la route appelé
-
-  final url = Uri.parse('http://localhost:3000/reservations');
-  final headers = {
-    'Content-Type': 'application/json',
-    'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImFkbWluQGFkbWluLmNvbSIsImlkIjoiYzk2ZTNlNjctNTVjZC00YmRhLTgzNDItNThjZjA4MTA5MzExIiwicm9sZXMiOlsiYWRtaW4iXSwiaWF0IjoxNzQ4MjY1Mjc1LCJleHAiOjE3NDgyNjg4NzV9.e4ubDT46erHIjYIjkk_3JScRJive9LztvPccI5dsfxc',
-  };
-
-  final response = await http.get(url, headers: headers);
+  final baseUrl = _getBaseUrl();
+  final url = Uri.parse('$baseUrl/reservations');
+  
+  final response = await http.get(url, headers: Env.defaultHeaders);
 
   if (response.statusCode == 200) {
     final List<dynamic> data = jsonDecode(response.body);
-
     return data.map((json) => Reservation.fromJson(json)).toList();
   } else {
     throw Exception('Erreur de chargement des réservations');
@@ -25,17 +20,14 @@ Future<List<Reservation>> fetchReservations() async {
 }
 
 Future<void> updateReservationStatus(String reservationId, String newStatus) async {
-  final url = Uri.parse('http://10.0.2.2:3000/reservations/$reservationId/status');
-  final headers = {
-    'Content-Type': 'application/json',
-    'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImFkbWluQGFkbWluLmNvbSIsImlkIjoiYzk2ZTNlNjctNTVjZC00YmRhLTgzNDItNThjZjA4MTA5MzExIiwicm9sZXMiOlsiYWRtaW4iXSwiaWF0IjoxNzQ4MjY1Mjc1LCJleHAiOjE3NDgyNjg4NzV9.e4ubDT46erHIjYIjkk_3JScRJive9LztvPccI5dsfxc',
-  };
+  final baseUrl = _getBaseUrl();
+  final url = Uri.parse('$baseUrl/reservations/$reservationId/status');
 
   final body = jsonEncode({
     'status': newStatus,
   });
 
-  final response = await http.patch(url, headers: headers, body: body);
+  final response = await http.patch(url, headers: Env.defaultHeaders, body: body);
 
   if (response.statusCode != 200) {
     throw Exception('Erreur lors de la mise à jour du statut de la réservation');
@@ -48,7 +40,8 @@ Future<void> bookTable({
   required String date,
   required String heure,
 }) async {
-  final url = Uri.parse('https://tonapi.com/reservations');
+  final baseUrl = _getBaseUrl();
+  final url = Uri.parse('$baseUrl/reservations');
 
   final body = jsonEncode({
     'nom': nom,
@@ -57,12 +50,7 @@ Future<void> bookTable({
     'heure': heure,      // Exemple: "19:30"
   });
 
-  final headers = {
-    'Content-Type': 'application/json',
-    'Authorization': 'Bearer ton_token_si_necessaire',
-  };
-
-  final response = await http.post(url, headers: headers, body: body);
+  final response = await http.post(url, headers: Env.defaultHeaders, body: body);
 
   if (response.statusCode == 200 || response.statusCode == 201) {
     print('Réservation réussie : ${response.body}');
@@ -70,4 +58,20 @@ Future<void> bookTable({
     print('Erreur : ${response.statusCode} - ${response.body}');
     throw Exception('Échec de la réservation');
   }
+}
+
+String _getBaseUrl() {
+  if (kIsWeb) {
+    return Env.apiUrl;
+  }
+  
+  if (Platform.isAndroid) {
+    return Env.androidApiUrl;
+  }
+  
+  if (Platform.isIOS) {
+    return Env.iosApiUrl;
+  }
+  
+  return Env.apiUrl;
 }

--- a/app/lib/service/reservation_service.dart
+++ b/app/lib/service/reservation_service.dart
@@ -7,7 +7,7 @@ import '../models/reservation.dart';
 Future<List<Reservation>> fetchReservations() async {
   // TODO En fonction de l'utilisateur changé la route appelé
 
-  final url = Uri.parse('http://10.0.2.2:3000/reservations');
+  final url = Uri.parse('http://localhost:3000/reservations');
   final headers = {
     'Content-Type': 'application/json',
     'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImFkbWluQGFkbWluLmNvbSIsImlkIjoiYzk2ZTNlNjctNTVjZC00YmRhLTgzNDItNThjZjA4MTA5MzExIiwicm9sZXMiOlsiYWRtaW4iXSwiaWF0IjoxNzQ4MjY1Mjc1LCJleHAiOjE3NDgyNjg4NzV9.e4ubDT46erHIjYIjkk_3JScRJive9LztvPccI5dsfxc',
@@ -21,6 +21,24 @@ Future<List<Reservation>> fetchReservations() async {
     return data.map((json) => Reservation.fromJson(json)).toList();
   } else {
     throw Exception('Erreur de chargement des réservations');
+  }
+}
+
+Future<void> updateReservationStatus(String reservationId, String newStatus) async {
+  final url = Uri.parse('http://10.0.2.2:3000/reservations/$reservationId/status');
+  final headers = {
+    'Content-Type': 'application/json',
+    'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImFkbWluQGFkbWluLmNvbSIsImlkIjoiYzk2ZTNlNjctNTVjZC00YmRhLTgzNDItNThjZjA4MTA5MzExIiwicm9sZXMiOlsiYWRtaW4iXSwiaWF0IjoxNzQ4MjY1Mjc1LCJleHAiOjE3NDgyNjg4NzV9.e4ubDT46erHIjYIjkk_3JScRJive9LztvPccI5dsfxc',
+  };
+
+  final body = jsonEncode({
+    'status': newStatus,
+  });
+
+  final response = await http.patch(url, headers: headers, body: body);
+
+  if (response.statusCode != 200) {
+    throw Exception('Erreur lors de la mise à jour du statut de la réservation');
   }
 }
 


### PR DESCRIPTION
This pull request introduces several changes to enhance the backend and frontend functionality, focusing on enabling CORS in the API, improving environment configuration, and adding an admin reservations management feature. The most important changes are grouped by theme below.

### Backend Enhancements:
* Enabled CORS in the `bootstrap` function of `api/src/main.ts` to allow cross-origin requests, supporting all methods and credentials.

### Environment Configuration:
* Added a new `env.dart.example` file to centralize API URLs and authentication tokens for different platforms (web, Android, iOS). This improves maintainability and security by replacing hardcoded values.
* Updated `app/.gitignore` to exclude the `env.dart` file, ensuring sensitive data is not committed to version control.

### Admin Reservations Management:
* Introduced a new `AdminReservationsPage` in `app/lib/pages/admin_reservations_page.dart` for managing reservations, including viewing, accepting, and rejecting reservations.
* Updated the main navigation in `app/lib/main.dart` to include the new "Admin" tab, allowing admins to access the reservations management page. [[1]](diffhunk://#diff-43a41aed8f4bf51ecb85660250a9e01f6b783178ba5d5317606bda12467ddb82L47-R49) [[2]](diffhunk://#diff-43a41aed8f4bf51ecb85660250a9e01f6b783178ba5d5317606bda12467ddb82L91-R99)

### Reservation Model and Service Updates:
* Added an `id` field to the `Reservation` model in `app/lib/models/reservation.dart` and updated the `fromJson` method to parse it from API responses. [[1]](diffhunk://#diff-59a2a144562be0c9aaed1b76c679f11ed038facd4bfe863d3352c4b23c4b6ae5R5-R13) [[2]](diffhunk://#diff-59a2a144562be0c9aaed1b76c679f11ed038facd4bfe863d3352c4b23c4b6ae5R24)
* Refactored `reservation_service.dart` to use the centralized environment configuration for API URLs and headers, improving flexibility across platforms. Added a new `updateReservationStatus` method for updating reservation statuses. [[1]](diffhunk://#diff-b78e8ac626a177a8ec4ba19ad9a24ca6c70f18b6d16c0adde6ef84a3325b78c9L2-R44) [[2]](diffhunk://#diff-b78e8ac626a177a8ec4ba19ad9a24ca6c70f18b6d16c0adde6ef84a3325b78c9L42-R53) [[3]](diffhunk://#diff-b78e8ac626a177a8ec4ba19ad9a24ca6c70f18b6d16c0adde6ef84a3325b78c9R62-R77)