### PR TITLE
Fix/admin reservation model

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -68,6 +68,7 @@ docker-compose up -d
 - `GET /reservations` - Liste des réservations (Admin)
 - `GET /reservations/:id` - Détails d'une réservation (Admin)
 - `PUT /reservations/:id` - Mise à jour d'une réservation (Admin)
+- `POST /reservations/:id/status` - Mise à jour du statut d'une réservation (Admin)
 - `DELETE /reservations/:id` - Suppression d'une réservation (Admin)
 
 ## Sécurité

--- a/api/bruno/reservations/update status.bru
+++ b/api/bruno/reservations/update status.bru
@@ -1,0 +1,26 @@
+meta {
+  name: update status
+  type: http
+  seq: 6
+}
+
+put {
+  url: {{host}}/reservations/:id
+  body: json
+  auth: bearer
+}
+
+params:path {
+  id: 2
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+body:json {
+  {
+    "name": "test mathis",
+    "capacity": 10
+  }
+}

--- a/api/src/reservation/dto/update-reservation-status.dto.ts
+++ b/api/src/reservation/dto/update-reservation-status.dto.ts
@@ -1,0 +1,8 @@
+import { IsEnum, IsNotEmpty } from 'class-validator';
+import { ReservationStatus } from '../entities/reservation.entity';
+
+export class UpdateReservationStatusDto {
+  @IsNotEmpty()
+  @IsEnum(ReservationStatus)
+  status: ReservationStatus;
+} 

--- a/api/src/reservation/reservation.controller.ts
+++ b/api/src/reservation/reservation.controller.ts
@@ -17,6 +17,7 @@ import { RolesGuard } from 'src/auth/roles.guard';
 import { UsersService } from 'src/users/users.service';
 import { CheckAvailabilityDto } from './dto/check-availability.dto';
 import { CreateReservationDto } from './dto/create-reservation.dto';
+import { UpdateReservationStatusDto } from './dto/update-reservation-status.dto';
 import { UpdateReservationDto } from './dto/update-reservation.dto';
 import { Reservation } from './entities/reservation.entity';
 import { ReservationService } from './reservation.service';
@@ -66,6 +67,20 @@ export class ReservationController {
     return plainToInstance(
       Reservation,
       this.reservationsService.update(id, updateReservationDto),
+    );
+  }
+
+  @Post(':id/status')
+  @Roles('admin')
+  @UseGuards(AccessGuard)
+  @UseAbility(Actions.update, UpdateReservationStatusDto)
+  updateStatus(
+    @Param('id') id: number,
+    @Body() updateReservationStatusDto: UpdateReservationStatusDto,
+  ) {
+    return plainToInstance(
+      Reservation,
+      this.reservationsService.updateStatus(id, updateReservationStatusDto.status),
     );
   }
 

--- a/api/src/reservation/reservation.permissions.ts
+++ b/api/src/reservation/reservation.permissions.ts
@@ -1,11 +1,12 @@
 import { Actions, InferSubjects, Permissions } from 'nest-casl';
 import Role from 'src/auth/roles';
 import { CreateReservationDto } from './dto/create-reservation.dto';
+import { UpdateReservationStatusDto } from './dto/update-reservation-status.dto';
 import { UpdateReservationDto } from './dto/update-reservation.dto';
 import { Reservation } from './entities/reservation.entity';
 
 export type Subjects = InferSubjects<
-  typeof CreateReservationDto | typeof UpdateReservationDto | typeof Reservation
+  typeof CreateReservationDto | typeof UpdateReservationDto | typeof UpdateReservationStatusDto | typeof Reservation
 >;
 
 export const permissions: Permissions<Role, Subjects, Actions> = {
@@ -16,6 +17,7 @@ export const permissions: Permissions<Role, Subjects, Actions> = {
   admin({ can }) {
     can(Actions.read, Reservation);
     can(Actions.update, UpdateReservationDto);
+    can(Actions.update, UpdateReservationStatusDto);
     can(Actions.delete, Reservation);
   },
 };

--- a/api/src/reservation/reservation.service.ts
+++ b/api/src/reservation/reservation.service.ts
@@ -6,7 +6,7 @@ import { User } from 'src/users/entities/user.entity';
 import { Repository } from 'typeorm';
 import { CreateReservationDto } from './dto/create-reservation.dto';
 import { UpdateReservationDto } from './dto/update-reservation.dto';
-import { Reservation } from './entities/reservation.entity';
+import { Reservation, ReservationStatus } from './entities/reservation.entity';
 
 @Injectable()
 export class ReservationService {
@@ -170,5 +170,10 @@ export class ReservationService {
 
     console.log('Résultat final:', availability);
     return availability;
+  }
+
+  async updateStatus(id: number, status: ReservationStatus) {
+    await this.reservationsRepository.update(id, { status });
+    return this.findOne(id);
   }
 }

--- a/app/lib/models/reservation.dart
+++ b/app/lib/models/reservation.dart
@@ -2,31 +2,42 @@ import 'package:flutter_restaurant_app/models/restaurant_table.dart';
 import 'package:flutter_restaurant_app/models/time_slots.dart';
 
 class Reservation {
-  final String id;
+  final int id;
   final int covers;
-  final String date;
+  final String reservationDate;
   final TimeSlots timeSlot;
   final RestaurantTable restaurantTable;
   final String status;
+  final DateTime createdAt;
+  final DateTime updatedAt;
 
   Reservation({
     required this.id,
     required this.covers,
-    required this.date,
+    required this.reservationDate,
     required this.timeSlot,
     required this.restaurantTable,
     required this.status,
+    required this.createdAt,
+    required this.updatedAt,
   });
 
   factory Reservation.fromJson(Map<String, dynamic> json) {
-    print(json);
     return Reservation(
       id: json['id'],
       covers: json['covers'],
-      date: json['reservationDate'],
-      timeSlot: new TimeSlots(startTime: json['timeSlot']['startTime'], endTime: json['timeSlot']['endTime']),
-      restaurantTable: new RestaurantTable(name: json["table"]["name"], capacity: json["table"]["capacity"]),
-      status: json["status"],
+      reservationDate: json['reservationDate'],
+      timeSlot: TimeSlots(
+        startTime: json['timeSlot']['startTime'],
+        endTime: json['timeSlot']['endTime']
+      ),
+      restaurantTable: RestaurantTable(
+        name: json['table']['name'],
+        capacity: json['table']['capacity']
+      ),
+      status: json['status'],
+      createdAt: DateTime.parse(json['createdAt']),
+      updatedAt: DateTime.parse(json['updatedAt']),
     );
   }
 }

--- a/app/lib/pages/admin_reservations_page.dart
+++ b/app/lib/pages/admin_reservations_page.dart
@@ -112,12 +112,12 @@ class _AdminReservationsPageState extends State<AdminReservationsPage> {
                   if (reservation.status.toLowerCase() == 'pending')
                     IconButton(
                       icon: const Icon(Icons.check, color: Colors.green),
-                      onPressed: () => _updateReservationStatus(reservation, 'CONFIRMED'),
+                      onPressed: () => _updateReservationStatus(reservation, 'confirmed'),
                     ),
-                  if (reservation.status.toLowerCase() == 'pending')
+                  if (reservation.status.toLowerCase() == 'pending' || reservation.status.toLowerCase() == 'confirmed')
                     IconButton(
                       icon: const Icon(Icons.close, color: Colors.red),
-                      onPressed: () => _updateReservationStatus(reservation, 'REFUSED'),
+                      onPressed: () => _updateReservationStatus(reservation, 'refused'),
                     ),
                 ],
               ),

--- a/app/lib/pages/admin_reservations_page.dart
+++ b/app/lib/pages/admin_reservations_page.dart
@@ -15,6 +15,19 @@ class _AdminReservationsPageState extends State<AdminReservationsPage> {
   bool _isLoading = true;
   String _error = '';
 
+  String _getStatusInFrench(String status) {
+    switch (status.toLowerCase()) {
+      case 'pending':
+        return 'En attente';
+      case 'accepted':
+        return 'Acceptée';
+      case 'rejected':
+        return 'Refusée';
+      default:
+        return status;
+    }
+  }
+
   @override
   void initState() {
     super.initState();
@@ -43,8 +56,8 @@ class _AdminReservationsPageState extends State<AdminReservationsPage> {
 
   Future<void> _updateReservationStatus(Reservation reservation, String newStatus) async {
     try {
-      await updateReservationStatus(reservation.id, newStatus);
-      await _loadReservations(); // Recharger les réservations après la mise à jour
+      await updateReservationStatus(reservation.id.toString(), newStatus);
+      await _loadReservations();
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Statut mis à jour avec succès')),
       );
@@ -86,20 +99,20 @@ class _AdminReservationsPageState extends State<AdminReservationsPage> {
               subtitle: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text('Date: ${reservation.date}'),
+                  Text('Date: ${reservation.reservationDate}'),
                   Text('Horaire: ${reservation.timeSlot.startTime} - ${reservation.timeSlot.endTime}'),
-                  Text('Statut: ${reservation.status}'),
+                  Text('Statut: ${_getStatusInFrench(reservation.status)}'),
                 ],
               ),
               trailing: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  if (reservation.status == 'PENDING')
+                  if (reservation.status.toLowerCase() == 'pending')
                     IconButton(
                       icon: const Icon(Icons.check, color: Colors.green),
                       onPressed: () => _updateReservationStatus(reservation, 'ACCEPTED'),
                     ),
-                  if (reservation.status == 'PENDING')
+                  if (reservation.status.toLowerCase() == 'pending')
                     IconButton(
                       icon: const Icon(Icons.close, color: Colors.red),
                       onPressed: () => _updateReservationStatus(reservation, 'REJECTED'),

--- a/app/lib/pages/admin_reservations_page.dart
+++ b/app/lib/pages/admin_reservations_page.dart
@@ -19,10 +19,12 @@ class _AdminReservationsPageState extends State<AdminReservationsPage> {
     switch (status.toLowerCase()) {
       case 'pending':
         return 'En attente';
-      case 'accepted':
+      case 'confirmed':
         return 'Acceptée';
-      case 'rejected':
+      case 'refused':
         return 'Refusée';
+      case 'cancelled':
+        return 'Annulée';
       default:
         return status;
     }
@@ -110,12 +112,12 @@ class _AdminReservationsPageState extends State<AdminReservationsPage> {
                   if (reservation.status.toLowerCase() == 'pending')
                     IconButton(
                       icon: const Icon(Icons.check, color: Colors.green),
-                      onPressed: () => _updateReservationStatus(reservation, 'ACCEPTED'),
+                      onPressed: () => _updateReservationStatus(reservation, 'CONFIRMED'),
                     ),
                   if (reservation.status.toLowerCase() == 'pending')
                     IconButton(
                       icon: const Icon(Icons.close, color: Colors.red),
-                      onPressed: () => _updateReservationStatus(reservation, 'REJECTED'),
+                      onPressed: () => _updateReservationStatus(reservation, 'REFUSED'),
                     ),
                 ],
               ),

--- a/app/lib/service/reservation_service.dart
+++ b/app/lib/service/reservation_service.dart
@@ -27,10 +27,11 @@ Future<void> updateReservationStatus(String reservationId, String newStatus) asy
     'status': newStatus,
   });
 
-  final response = await http.patch(url, headers: Env.defaultHeaders, body: body);
+  final response = await http.post(url, headers: Env.defaultHeaders, body: body);
+  print('Response status code: ${response.statusCode}');
 
-  if (response.statusCode != 200) {
-    throw Exception('Erreur lors de la mise à jour du statut de la réservation');
+  if (response.statusCode != 201) {
+    throw Exception('Erreur lors de la mise à jour du statut de la réservation : ${response.body}');
   }
 }
 


### PR DESCRIPTION
This pull request introduces a feature to update the status of reservations, along with several related improvements across the backend and frontend. Key changes include the addition of a new API endpoint, updates to the reservation model and service, and enhancements to the admin interface for managing reservation statuses.

### Backend Changes

* **New API Endpoint for Updating Reservation Status:**
  - Added a `POST /reservations/:id/status` endpoint in the `ReservationController` to allow admins to update reservation statuses. This includes role-based access control and validation using `UpdateReservationStatusDto`.
  - Created the `UpdateReservationStatusDto` class to validate incoming status updates with `class-validator`.

* **Service and Permissions Updates:**
  - Implemented `updateStatus` in `ReservationService` to handle the status update logic and return the updated reservation.
  - Updated permissions in `reservation.permissions.ts` to allow admins to perform the `update` action on `UpdateReservationStatusDto`.

### Frontend Changes

* **Reservation Model Enhancements:**
  - Updated the `Reservation` model to include `createdAt` and `updatedAt` fields, and renamed `date` to `reservationDate` for consistency.

* **Admin Interface Improvements:**
  - Added a `_getStatusInFrench` method in `AdminReservationsPage` to display statuses in French.
  - Updated the admin reservations page to use the new API endpoint and handle status updates dynamically. Statuses are now displayed in French, and buttons are conditionally rendered based on the current status. [[1]](diffhunk://#diff-2bba02aa05a87141c70b37ed3f2c86f01af640864a85d6a6dd8f4a7971be665dL89-R120) [[2]](diffhunk://#diff-2bba02aa05a87141c70b37ed3f2c86f01af640864a85d6a6dd8f4a7971be665dL46-R62)

* **Service Update for Status Changes:**
  - Modified the `updateReservationStatus` method in `reservation_service.dart` to use `POST` instead of `PATCH` for the new endpoint, with improved error handling.