### PR TITLE
fix: consider reservation status when checking availability

### DIFF
--- a/api/src/reservation/reservation.service.ts
+++ b/api/src/reservation/reservation.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { TableEntity } from 'src/tables/entities/table.entity';
 import { TimeSlot } from 'src/time-slots/entities/time-slot.entity';
 import { User } from 'src/users/entities/user.entity';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { CreateReservationDto } from './dto/create-reservation.dto';
 import { UpdateReservationDto } from './dto/update-reservation.dto';
 import { Reservation, ReservationStatus } from './entities/reservation.entity';
@@ -107,6 +107,7 @@ export class ReservationService {
     const reservations = await this.reservationsRepository.find({
       where: {
         reservationDate: new Date(date),
+        status: In([ReservationStatus.PENDING, ReservationStatus.CONFIRMED])
       },
       relations: {
         table: true,


### PR DESCRIPTION
This pull request updates the `ReservationService` in `api/src/reservation/reservation.service.ts` to enhance reservation filtering by status. The main changes involve importing the `In` operator from TypeORM and using it to filter reservations based on their status.

### Reservation Filtering Enhancements:

* [`api/src/reservation/reservation.service.ts`](diffhunk://#diff-e826868f8470f8c449982f2b42563ffbccabdc90fad93cfe0c97e96a72bb4eabL6-R6): Added the `In` operator from TypeORM to filter reservations by status (`PENDING` or `CONFIRMED`) when querying reservations for a specific date. [[1]](diffhunk://#diff-e826868f8470f8c449982f2b42563ffbccabdc90fad93cfe0c97e96a72bb4eabL6-R6) [[2]](diffhunk://#diff-e826868f8470f8c449982f2b42563ffbccabdc90fad93cfe0c97e96a72bb4eabR110)